### PR TITLE
refactor receiveMessage: use loop to receive data until newline and adjust buffer handling

### DIFF
--- a/modules/tcp_performConnection/performConnection.c
+++ b/modules/tcp_performConnection/performConnection.c
@@ -37,7 +37,8 @@ int receiveMessage(int sockfd, char *buffer, size_t buffer_size) {
   size_t total_received = 0; // Total length of the received data
   while (total_received < buffer_size - 1) {
     char temp_buffer[2]; // Temporary buffer for a single character
-    ssize_t bytes_received = recv(sockfd, temp_buffer, 1, 0); // Receive one character
+    ssize_t bytes_received =
+      recv(sockfd, temp_buffer, 1, 0); // Receive one character
 
     if (bytes_received < 0) {
       fprintf(stderr, "Error receiving message: %s\n", strerror(errno));

--- a/modules/tcp_performConnection/performConnection.c
+++ b/modules/tcp_performConnection/performConnection.c
@@ -34,7 +34,8 @@ int sendMessage(int sockfd, const char *message) {
  * @return int EXIT_SUCCESS on success, EXIT_FAILURE on error.
  */
 int receiveMessage(int sockfd, char *buffer, size_t buffer_size) {
-  if (buffer_size <= 1) {
+  if (buffer_size
+      <= 1) { // Check buffer_size to prevent overflow or invalid memory access
     fprintf(stderr, "Invalid buffer size.\n");
     return EXIT_FAILURE;
   }

--- a/modules/tcp_performConnection/performConnection.c
+++ b/modules/tcp_performConnection/performConnection.c
@@ -34,15 +34,32 @@ int sendMessage(int sockfd, const char *message) {
  * @return int EXIT_SUCCESS on success, EXIT_FAILURE on error.
  */
 int receiveMessage(int sockfd, char *buffer, size_t buffer_size) {
-  ssize_t bytes_received = recv(sockfd, buffer, buffer_size - 1, 0);
-  if (bytes_received < 0) {
-    fprintf(stderr, "Error receiving message: %s\n", strerror(errno));
-    return EXIT_FAILURE;
-  } else if (bytes_received == 0) {
-    fprintf(stderr, "Connection closed by server.\n");
-    return EXIT_FAILURE;
+  size_t total_received = 0; // Total length of the received data
+  while (total_received < buffer_size - 1) {
+    char temp_buffer[2]; // Temporary buffer for a single character
+    ssize_t bytes_received = recv(sockfd, temp_buffer, 1, 0); // Receive one character
+
+    if (bytes_received < 0) {
+      fprintf(stderr, "Error receiving message: %s\n", strerror(errno));
+      return EXIT_FAILURE;
+    } else if (bytes_received == 0) {
+      fprintf(stderr, "Connection closed by server.\n");
+      return EXIT_FAILURE;
+    }
+
+    // Append the received character to the buffer
+    buffer[total_received] = temp_buffer[0];
+    total_received++;
+
+    // Stop if a newline character is found
+    if (temp_buffer[0] == '\n') {
+      break;
+    }
   }
-  buffer[bytes_received] = '\0';
+
+  // Add a null terminator to make the buffer a valid string
+  buffer[total_received] = '\0';
+
   fprintf(stdout, "S: %s", buffer);
   return EXIT_SUCCESS;
 }

--- a/modules/tcp_performConnection/performConnection.c
+++ b/modules/tcp_performConnection/performConnection.c
@@ -34,9 +34,14 @@ int sendMessage(int sockfd, const char *message) {
  * @return int EXIT_SUCCESS on success, EXIT_FAILURE on error.
  */
 int receiveMessage(int sockfd, char *buffer, size_t buffer_size) {
+  if (buffer_size <= 1) {
+    fprintf(stderr, "Invalid buffer size.\n");
+    return EXIT_FAILURE;
+  }
+
   size_t total_received = 0; // Total length of the received data
   while (total_received < buffer_size - 1) {
-    char temp_buffer[2]; // Temporary buffer for a single character
+    char temp_buffer[2] = {0}; // Temporary buffer for a single character
     ssize_t bytes_received =
       recv(sockfd, temp_buffer, 1, 0); // Receive one character
 
@@ -45,6 +50,9 @@ int receiveMessage(int sockfd, char *buffer, size_t buffer_size) {
       return EXIT_FAILURE;
     } else if (bytes_received == 0) {
       fprintf(stderr, "Connection closed by server.\n");
+      return EXIT_FAILURE;
+    } else if (bytes_received > 1) {
+      fprintf(stderr, "Unexpected bytes received: %zd\n", bytes_received);
       return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
### **User description**
### Refactor der `receiveMessage` Funktion

- Die Funktion empfängt nun Daten Byte für Byte bis zum Zeilenumbruch (`\n`) oder bis der Puffer voll ist.
- Ein temporärer Puffer (`temp_buffer[2]`) wird verwendet, um jeweils ein Byte zu empfangen und an den Hauptpuffer anzuhängen.
- Die Schleife bricht ab, sobald ein Zeilenumbruch empfangen wird.
- Verbesserte Fehlerbehandlung bei Empfangsfehlern oder Verbindungsabbrüchen.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored the `receiveMessage` function to use a loop for receiving data byte-by-byte until a newline character or buffer limit is reached.
- Introduced a temporary buffer (`temp_buffer[2]`) for handling single-byte reception and appending to the main buffer.
- Improved error handling for cases of reception errors or connection closure.
- Ensured the buffer is null-terminated to maintain string validity.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>performConnection.c</strong><dd><code>Refactor and improve `receiveMessage` function for robustness</code></dd></summary>
<hr>

modules/tcp_performConnection/performConnection.c

<li>Refactored <code>receiveMessage</code> function to receive data byte-by-byte until <br>a newline or buffer limit is reached.<br> <li> Introduced a temporary buffer (<code>temp_buffer[2]</code>) for single-byte <br>reception.<br> <li> Improved error handling for connection closure and reception errors.<br> <li> Added null terminator to ensure the buffer is a valid string.<br>


</details>


  </td>
  <td><a href="https://github.com/noluyorAbi/C-Project/pull/29/files#diff-984e74d1b03c4aafe88a26e4b34a74cf255bbc04741004fc1751bf82cc522357">+25/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information